### PR TITLE
feat: #11 마이페이지 및 회원 복구 기능 개발

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import CoupleConnect from "./pages/authCouple/index.jsx";
 import OAuth2RedirectHandler from "./pages/auth/OAuthRedirectHandler.jsx"; // OAuth 리다이렉트 핸들러 컴포넌트
 import AdditionalInfo from "./pages/authAdditionalInfo/index.jsx"; // 추가 정보 입력 페이지
 import MyPage from "./pages/mypage/index.jsx";
+import AccountRecovery from "./pages/accountRecovery/index.jsx";
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
         <Route path="/additional-info" element={<AdditionalInfo />} />
         <Route path="/connect" element={<CoupleConnect />} />
         <Route path="/mypage" element={<MyPage />} />
+        <Route path="/recover" element={<AccountRecovery />} />
         <Route path="/" element={<Login />} />
       </Routes>
     </Router>

--- a/src/pages/accountRecovery/index.jsx
+++ b/src/pages/accountRecovery/index.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../../api/axiosInstance"; // axiosInstance.js 경로에 맞게 수정
+
+function AccountRecovery() {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleRecover = async () => {
+    try {
+      setIsLoading(true);
+
+      // 로컬 스토리지에서 사용자 정보 가져오기
+      const userInfo = JSON.parse(localStorage.getItem("loginUserInfo"));
+
+      // API를 통해 계정 복구 요청
+      await api.post("/api/v1/users/me/recover", {});
+
+      // 로컬 스토리지의 status 업데이트
+      userInfo.status = "ACTIVE";
+      localStorage.setItem("loginUserInfo", JSON.stringify(userInfo));
+
+      alert("계정이 성공적으로 복구되었습니다.");
+      navigate("/home");
+    } catch (error) {
+      console.error("계정 복구 실패:", error);
+      alert("계정 복구에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    // 로그인 페이지로 이동
+    localStorage.removeItem("loginUserInfo");
+    localStorage.removeItem("accessToken");
+    navigate("/login");
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-mainbg font-noto">
+      <div className="bg-cardbg p-8 rounded-[18px] shadow-md w-[360px] text-center">
+        <div className="mb-6">
+          <h2 className="text-2xl font-bold text-textmain mb-2">계정 복구</h2>
+          <p className="text-textsub">
+            계정이 비활성화 상태입니다.
+            <br />
+            계정을 복구하시겠습니까?
+          </p>
+        </div>
+
+        <div className="bg-white p-4 rounded-lg mb-6 text-left">
+          <p className="text-sm text-textsub mb-2">안내사항</p>
+          <ul className="text-sm text-textmain list-disc pl-5 space-y-1">
+            <li>계정 복구 시 기존 데이터가 모두 유지됩니다.</li>
+            <li>복구를 취소하면 로그인 페이지로 이동합니다.</li>
+          </ul>
+        </div>
+
+        <div className="flex justify-center space-x-4">
+          <button
+            onClick={handleCancel}
+            className="px-6 py-2.5 rounded-lg border border-subpoint text-textmain hover:bg-gray-100"
+            disabled={isLoading}
+          >
+            취소하기
+          </button>
+          <button
+            onClick={handleRecover}
+            className="px-6 py-2.5 rounded-lg bg-point text-white hover:bg-opacity-90"
+            disabled={isLoading}
+          >
+            {isLoading ? "처리 중..." : "복구하기"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AccountRecovery;

--- a/src/pages/auth/OAuthRedirectHandler.jsx
+++ b/src/pages/auth/OAuthRedirectHandler.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import api from "../../api/axiosInstance"; // axiosInstance.js 경로에 맞게 수정
 
 const OAuth2RedirectHandler = () => {
   const navigate = useNavigate();
@@ -9,10 +9,9 @@ const OAuth2RedirectHandler = () => {
     const fetchUserInfo = async () => {
       try {
         console.log("get요청");
-        const response = await axios.get(
-          `http://localhost:8080/api/v1/auth/refresh-token`,
-          { withCredentials: true }
-        );
+        const response = await api.get(`/api/v1/auth/refresh-token`, {
+          withCredentials: true,
+        });
         console.log("전체 응답", response);
         if (response.data.data) {
           const loginUserInfo = {
@@ -28,15 +27,6 @@ const OAuth2RedirectHandler = () => {
 
           localStorage.setItem("loginUserInfo", JSON.stringify(loginUserInfo));
           localStorage.setItem("accessToken", accessToken);
-
-          // accessToken을 axios 기본 헤더에 저장
-          axios.defaults.headers.common[
-            "Authorization"
-          ] = `Bearer ${accessToken}`;
-          console.log(
-            "설정된 헤더",
-            axios.defaults.headers.common["Authorization"]
-          );
 
           // coupleId와 birth 유무에 따라 다른 페이지로 리다이렉트
           if (!loginUserInfo.birth) {

--- a/src/pages/auth/OAuthRedirectHandler.jsx
+++ b/src/pages/auth/OAuthRedirectHandler.jsx
@@ -20,6 +20,7 @@ const OAuth2RedirectHandler = () => {
             userCode: response.data.data.userCode,
             birth: response.data.data.birth,
             coupleId: response.data.data.coupleId,
+            status: response.data.data.status,
           };
           const accessToken = response.data.data.accessToken;
           console.log("로그인 유저 정보", loginUserInfo);
@@ -28,8 +29,13 @@ const OAuth2RedirectHandler = () => {
           localStorage.setItem("loginUserInfo", JSON.stringify(loginUserInfo));
           localStorage.setItem("accessToken", accessToken);
 
+          if (loginUserInfo.status === "INACTIVE") {
+            // 비활성화 상태일 경우
+            console.log("비활성화 상태: /recover로 리다이렉트");
+            navigate("/recover", { replace: true });
+          }
           // coupleId와 birth 유무에 따라 다른 페이지로 리다이렉트
-          if (!loginUserInfo.birth) {
+          else if (!loginUserInfo.birth) {
             // birth 정보가 없으면 추가 정보 입력 페이지로 우선 이동
             console.log("개인정보 입력 필요: /additional-info로 리다이렉트");
             navigate("/additional-info", { replace: true });

--- a/src/pages/auth/index.jsx
+++ b/src/pages/auth/index.jsx
@@ -14,7 +14,9 @@ function SocialLoginButton({ provider }) {
   };
 
   const handleLogin = () => {
-    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}`;
+    window.location.href = `${
+      import.meta.env.VITE_CORE_API_BASE_URL
+    }/oauth2/authorization/${provider}`;
   };
 
   return (

--- a/src/pages/authAdditionalInfo/index.jsx
+++ b/src/pages/authAdditionalInfo/index.jsx
@@ -1,7 +1,7 @@
 // src/pages/authAdditionalInfo/index.jsx
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import api from "../../api/axiosInstance";
 
 function AdditionalInfo() {
   const navigate = useNavigate();
@@ -88,9 +88,6 @@ function AdditionalInfo() {
     if (name === "privacyConsent") {
       // privacy 동의는 별도 상태로 관리하고
       setPrivacyConsent(checked);
-      // if (checked) {
-      //   setPrivacyError("");
-      // }
     } else {
       // 다른 입력 필드 처리
       setFormData({
@@ -125,21 +122,6 @@ function AdditionalInfo() {
     setError("");
 
     try {
-      // 로컬 스토리지에서 액세스 토큰 가져오기
-      const accessToken = localStorage.getItem("accessToken");
-
-      if (!accessToken) {
-        setError("로그인이 필요합니다.");
-        navigate("/", { replace: true });
-        return;
-      }
-
-      // 요청 헤더에 토큰 포함
-      const config = {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      };
       // 서버로 전송하기 전에 명시적으로 불리언 타입으로 변환
       const dataToSend = {
         ...formData,
@@ -147,8 +129,8 @@ function AdditionalInfo() {
       };
 
       // API 요청 보내기
-      const response = await axios.patch(
-        "http://localhost:8080/api/v1/users/me/additional-info",
+      const response = await api.patch(
+        "/api/v1/users/me/additional-info",
         dataToSend
       );
 

--- a/src/pages/authAdditionalInfo/index.jsx
+++ b/src/pages/authAdditionalInfo/index.jsx
@@ -137,11 +137,22 @@ function AdditionalInfo() {
       console.log("추가 정보 제출 응답:", response.data);
 
       // 로컬 스토리지에서 storedUserInfo 가져오기
-      const loginUserInfo = localStorage.getItem("loginUserInfo");
 
       if (response.data.success || response.status === 200) {
+        const loginUserInfo = localStorage.getItem("loginUserInfo");
+        const parsedUserInfo = JSON.parse(loginUserInfo);
+        // API 응답에서 birth 가져오기
+        const birth = response.data.data.birth;
+
+        // 기존 정보에 birth 추가
+        parsedUserInfo.birth = birth;
+
+        // 업데이트된 정보를 다시 로컬 스토리지에 저장
+        localStorage.setItem("loginUserInfo", JSON.stringify(parsedUserInfo));
+        const loginUserInfo2 = localStorage.getItem("loginUserInfo");
+
         // coupleId 유무에 따라 다른 페이지로 리다이렉트
-        if (!loginUserInfo.coupleId) {
+        if (!loginUserInfo2.coupleId) {
           // birth는 있지만 coupleId가 없으면 커플 연결 페이지로 이동
           console.log("커플 연결 필요: /connect로 리다이렉트");
           navigate("/connect", { replace: true });

--- a/src/pages/authCouple/index.jsx
+++ b/src/pages/authCouple/index.jsx
@@ -55,7 +55,23 @@ function CoupleConnect() {
 
       if (response.data.code === 200) {
         // 성공 시 홈 페이지로 이동
+        const storedUserInfo = localStorage.getItem("loginUserInfo");
+
+        if (storedUserInfo) {
+          const parsedUserInfo = JSON.parse(storedUserInfo);
+
+          // API 응답에서 coupleId 가져오기
+          const coupleId = response.data.data.coupleId;
+
+          // 기존 정보에 coupleId 추가, userCode 삭제
+          parsedUserInfo.coupleId = coupleId;
+          delete parsedUserInfo.userCode;
+
+          // 업데이트된 정보를 다시 로컬 스토리지에 저장
+          localStorage.setItem("loginUserInfo", JSON.stringify(parsedUserInfo));
+        }
         alert("커플 연결이 완료되었습니다!");
+
         navigate("/home", { replace: true });
       } else {
         setError(response.data.message || "연결에 실패했습니다.");

--- a/src/pages/authCouple/index.jsx
+++ b/src/pages/authCouple/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import axios from "axios";
+import api from "../../api/axiosInstance";
 
 function CoupleConnect() {
   const location = useLocation();
@@ -45,30 +45,11 @@ function CoupleConnect() {
     }
 
     try {
-      // 로컬 스토리지에서 액세스 토큰 가져오기
-      const accessToken = localStorage.getItem("accessToken");
-
-      if (!accessToken) {
-        setError("로그인이 필요합니다.");
-        navigate("/", { replace: true });
-        return;
-      }
-
-      // 요청 헤더에 토큰 포함
-      const config = {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      };
       // API 요청 보내기
-      const response = await axios.post(
-        "http://localhost:8080/api/v1/couples",
-        {
-          userCode: userCode,
-          coupleStartedDay: coupleStartedDay,
-        },
-        config
-      );
+      const response = await api.post("/api/v1/couples", {
+        userCode: userCode,
+        coupleStartedDay: coupleStartedDay,
+      });
 
       console.log("커플 연결 응답:", response.data);
 

--- a/src/pages/mypage/index.jsx
+++ b/src/pages/mypage/index.jsx
@@ -1,12 +1,17 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import api from "../../api/axiosInstance"; // axiosInstance.js 경로에 맞게 수정
 
 function MyPage() {
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const navigate = useNavigate();
+  const [maxDate, setMaxDate] = useState("");
+  const [minDate, setMinDate] = useState("");
+  const [birthError, setBirthError] = useState("");
+  const [usernameError, setUsernameError] = useState("");
 
   // 편집 상태 관리
   const [editingSection, setEditingSection] = useState(null);
@@ -15,23 +20,7 @@ function MyPage() {
   useEffect(() => {
     const fetchProfile = async () => {
       try {
-        const accessToken = localStorage.getItem("accessToken");
-        if (!accessToken) {
-          setError("로그인이 필요합니다.");
-          navigate("/", { replace: true });
-          return;
-        }
-
-        const config = {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        };
-
-        const response = await axios.get(
-          "http://localhost:8080/api/v1/users/me",
-          config
-        );
+        const response = await api.get("/api/v1/users/me");
         setProfile(response.data.data);
         setEditData(response.data.data); // 초기 편집 데이터 설정
         setLoading(false);
@@ -55,11 +44,94 @@ function MyPage() {
     };
 
     fetchProfile();
+
+    // 오늘 날짜를 yyyy-mm-dd 형식으로 구하기
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = String(today.getMonth() + 1).padStart(2, "0");
+    const day = String(today.getDate()).padStart(2, "0");
+    const formattedToday = `${year}-${month}-${day}`;
+    // 만 14세 이상만 선택 가능하도록 최소 날짜 설정
+    const minYear = year - 100; // 최대 100세
+    const maxYear = year - 14; // 최소 14세
+    const minDateValue = `${minYear}-01-01`;
+    const maxDateValue = `${maxYear}-${month}-${day}`;
+
+    setMaxDate(formattedToday);
+    setMinDate(minDateValue);
   }, [navigate]);
+  // 생년월일 유효성 검사 함수
+  const validateBirth = (birthDate) => {
+    if (!birthDate) {
+      setBirthError("생년월일을 입력해주세요.");
+      return false;
+    }
+
+    const today = new Date();
+    const birthDateObj = new Date(birthDate);
+
+    // 유효한 날짜인지 확인
+    if (isNaN(birthDateObj.getTime())) {
+      setBirthError("유효하지 않은 날짜입니다.");
+      return false;
+    }
+
+    // 미래 날짜인지 확인
+    if (birthDateObj > today) {
+      setBirthError("미래 날짜는 선택할 수 없습니다.");
+      return false;
+    }
+
+    // 만 14세 이상인지 확인
+    const minAgeDate = new Date();
+    minAgeDate.setFullYear(today.getFullYear() - 14);
+    if (birthDateObj > minAgeDate) {
+      setBirthError("만 14세 이상만 가입 가능합니다.");
+      return false;
+    }
+
+    // 100세 이하인지 확인
+    const maxAgeDate = new Date();
+    maxAgeDate.setFullYear(today.getFullYear() - 100);
+    if (birthDateObj < maxAgeDate) {
+      setBirthError("생년월일을 다시 확인해주세요.");
+      return false;
+    }
+
+    setBirthError("");
+    return true;
+  };
+
+  // 이름 유효성 검사 함수
+  const validateUsername = (username) => {
+    if (!username || username.trim() === "") {
+      setUsernameError("이름을 입력해주세요.");
+      return false;
+    }
+
+    if (username.trim().length < 2) {
+      setUsernameError("이름은 2글자 이상이어야 합니다.");
+      return false;
+    }
+
+    setUsernameError("");
+    return true;
+  };
 
   // 입력 변경 핸들러
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
+
+    // 생년월일 변경 시 유효성 검사
+    if (name === "birth") {
+      validateBirth(value);
+    }
+
+    // 이름 변경 시 유효성 검사
+    if (name === "username") {
+      validateUsername(value);
+    }
+
     setEditData({
       ...editData,
       [name]: type === "checkbox" ? checked : value,
@@ -68,45 +140,74 @@ function MyPage() {
 
   // 섹션 저장 핸들러
   const handleSaveSection = async (section) => {
+    // 프로필 섹션에서 이름 유효성 검사
+    if (section === "profile" && !validateUsername(editData.username)) {
+      return;
+    }
+
+    // 개인정보 섹션에서 생년월일 유효성 검사
+    if (section === "personal" && !validateBirth(editData.birth)) {
+      return;
+    }
+    // localStorage에서 데이터 가져오기
+    const loginUserInfoStr = localStorage.getItem("loginUserInfo");
+
+    // JSON 문자열을 객체로 변환
+    const loginUserInfo = JSON.parse(loginUserInfoStr);
+
+    // coupleId 추출
+    const coupleId = loginUserInfo.coupleId;
+
+    console.log(coupleId); // 1
     try {
-      const accessToken = localStorage.getItem("accessToken");
-      const config = {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      };
-
-      let endpoint = "http://localhost:8080/api/v1/users/me";
+      let endpoint = "";
       let data = {};
+      let response;
 
-      // 섹션별 데이터 준비
+      // 섹션별 엔드포인트와 데이터 준비
       if (section === "profile") {
+        endpoint = "/api/v1/users/me/profile";
         data = {
           username: editData.username,
           statusMessage: editData.statusMessage,
         };
       } else if (section === "personal") {
+        endpoint = "/api/v1/users/me/personal";
         data = {
           birth: editData.birth,
           location: editData.location,
         };
       } else if (section === "couple") {
+        endpoint = "/api/v1/users/me/coupleStartedDay";
         data = {
+          coupleId: coupleId,
           coupleStartedDay: editData.coupleStartedDay,
         };
       } else if (section === "marketing") {
+        endpoint = "/api/v1/users/me/marketing-consent";
         data = {
           marketingConsent: editData.marketingConsent,
         };
       }
 
-      const response = await axios.patch(endpoint, data, config);
+      // 해당 섹션의 API 호출
+      response = await api.patch(endpoint, data);
+
+      // 응답 데이터로 프로필 상태 업데이트
       setProfile({ ...profile, ...response.data.data });
       setEditingSection(null);
       alert("정보가 수정되었습니다.");
     } catch (error) {
       console.error("정보 수정 실패:", error);
-      alert("정보 수정에 실패했습니다.");
+      if (
+        error.response &&
+        error.response.data &&
+        error.response.data.message
+      ) {
+        alert(`정보 수정에 실패했습니다: ${error.response.data.message}`);
+      } else {
+        alert("정보 수정에 실패했습니다.");
+      }
     }
   };
 
@@ -116,14 +217,7 @@ function MyPage() {
 
   const handleBreakupCouple = async () => {
     try {
-      const accessToken = localStorage.getItem("accessToken");
-      const config = {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      };
-
-      await axios.delete("http://localhost:8080/api/v1/couples", config);
+      await api.delete("/api/v1/couples");
 
       alert("커플 연결이 해제되었습니다.");
       window.location.reload();
@@ -136,14 +230,7 @@ function MyPage() {
 
   const handleDeleteAccount = async () => {
     try {
-      const accessToken = localStorage.getItem("accessToken");
-      const config = {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      };
-
-      await axios.delete("http://localhost:8080/api/v1/users/me", config);
+      await api.delete("/api/v1/users/me");
 
       localStorage.removeItem("accessToken");
       alert("회원 탈퇴가 완료되었습니다.");
@@ -337,14 +424,21 @@ function MyPage() {
             <div className="mb-4">
               <p className="text-textsub mb-1">이름</p>
               {editingSection === "profile" ? (
-                <input
-                  type="text"
-                  name="username"
-                  value={editData.username || ""}
-                  onChange={handleChange}
-                  className="w-full p-2 border border-subpoint rounded-lg"
-                  placeholder="이름"
-                />
+                <div>
+                  <input
+                    type="text"
+                    name="username"
+                    value={editData.username || ""}
+                    onChange={handleChange}
+                    className={`w-full p-2 border ${
+                      usernameError ? "border-red-500" : "border-subpoint"
+                    } rounded-lg`}
+                    placeholder="이름 (2글자 이상)"
+                  />
+                  {usernameError && (
+                    <p className="text-red-500 text-xs mt-1">{usernameError}</p>
+                  )}
+                </div>
               ) : (
                 <p className="text-textmain">
                   {profile?.username || "이름 없음"}
@@ -413,13 +507,25 @@ function MyPage() {
         <div className="mb-4">
           <p className="text-textsub mb-1">생년월일</p>
           {editingSection === "personal" ? (
-            <input
-              type="date"
-              name="birth"
-              value={editData.birth || ""}
-              onChange={handleChange}
-              className="w-full p-2 border border-subpoint rounded-lg"
-            />
+            <div>
+              <input
+                type="date"
+                name="birth"
+                value={editData.birth || ""}
+                onChange={handleChange}
+                min={minDate}
+                max={maxDate}
+                className={`w-full p-2 border ${
+                  birthError ? "border-red-500" : "border-subpoint"
+                } rounded-lg`}
+              />
+              {birthError && (
+                <p className="text-red-500 text-xs mt-1">{birthError}</p>
+              )}
+              <p className="text-xs text-textsub mt-1">
+                만 14세 이상만 등록 가능합니다.
+              </p>
+            </div>
           ) : (
             <p className="text-textmain">{profile?.birth || "정보 없음"}</p>
           )}
@@ -429,14 +535,30 @@ function MyPage() {
         <div className="mb-0">
           <p className="text-textsub mb-1">지역</p>
           {editingSection === "personal" ? (
-            <input
-              type="text"
+            <select
               name="location"
               value={editData.location || ""}
               onChange={handleChange}
-              className="w-full p-2 border border-subpoint rounded-lg"
-              placeholder="지역을 입력하세요"
-            />
+              className="w-full p-2 border border-subpoint rounded-lg bg-white"
+            >
+              <option value="">지역을 선택해주세요</option>
+              <option value="서울">서울</option>
+              <option value="경기">경기</option>
+              <option value="인천">인천</option>
+              <option value="강원">강원</option>
+              <option value="충북">충북</option>
+              <option value="충남">충남</option>
+              <option value="대전">대전</option>
+              <option value="경북">경북</option>
+              <option value="경남">경남</option>
+              <option value="대구">대구</option>
+              <option value="울산">울산</option>
+              <option value="부산">부산</option>
+              <option value="전북">전북</option>
+              <option value="전남">전남</option>
+              <option value="광주">광주</option>
+              <option value="제주">제주</option>
+            </select>
           ) : (
             <p className="text-textmain">{profile?.location || "정보 없음"}</p>
           )}
@@ -484,6 +606,7 @@ function MyPage() {
               type="date"
               name="coupleStartedDay"
               value={editData.coupleStartedDay || ""}
+              max={maxDate}
               onChange={handleChange}
               className="w-full p-2 border border-subpoint rounded-lg"
             />
@@ -504,33 +627,10 @@ function MyPage() {
       <div className="bg-cardbg rounded-lg p-6 mb-6 shadow-sm">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-bold text-point">마케팅 수신 정보</h3>
-          {editingSection !== "marketing" ? (
-            <button
-              className="text-point text-sm font-medium"
-              onClick={() => setEditingSection("marketing")}
-            >
-              수정
-            </button>
-          ) : (
-            <div className="flex space-x-2">
-              <button
-                className="text-gray-500 text-sm font-medium"
-                onClick={() => setEditingSection(null)}
-              >
-                취소
-              </button>
-              <button
-                className="text-point text-sm font-medium"
-                onClick={() => handleSaveSection("marketing")}
-              >
-                저장
-              </button>
-            </div>
-          )}
         </div>
 
-        <div className="flex items-center justify-between">
-          <div>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+          <div className="mb-3 sm:mb-0">
             <p className="text-textmain">마케팅 정보 수신 동의</p>
             <p className="text-textsub text-sm">
               이벤트 및 프로모션 정보를 이메일로 받아보실 수 있습니다.
@@ -541,25 +641,39 @@ function MyPage() {
               type="checkbox"
               name="marketingConsent"
               className="sr-only peer"
-              checked={
-                editingSection === "marketing"
-                  ? editData.marketingConsent || false
-                  : profile.marketingConsent || false
-              }
-              onChange={
-                editingSection === "marketing" ? handleChange : undefined
-              }
-              readOnly={editingSection !== "marketing"}
+              checked={profile.marketingConsent || false}
+              onChange={async (e) => {
+                try {
+                  const newValue = e.target.checked;
+
+                  // 임시로 UI 상태 업데이트 (즉각적인 피드백)
+                  setProfile({
+                    ...profile,
+                    marketingConsent: newValue,
+                  });
+
+                  await api.patch("/api/v1/users/me/marketing-consent", {
+                    marketingConsent: newValue,
+                  });
+
+                  // 성공 시 알림 (선택 사항)
+                  console.log("마케팅 수신 설정이 변경되었습니다.");
+                } catch (error) {
+                  console.error("마케팅 수신 설정 변경 실패:", error);
+
+                  // 실패 시 원래 상태로 되돌림
+                  setProfile({
+                    ...profile,
+                    marketingConsent: !e.target.checked,
+                  });
+
+                  alert("마케팅 수신 설정 변경에 실패했습니다.");
+                }
+              }}
             />
             <div
               className={`w-11 h-6 rounded-full peer ${
-                (
-                  editingSection === "marketing"
-                    ? editData.marketingConsent
-                    : profile.marketingConsent
-                )
-                  ? "bg-point"
-                  : "bg-gray-300"
+                profile.marketingConsent ? "bg-point" : "bg-gray-300"
               } peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all`}
             ></div>
           </label>
@@ -571,15 +685,15 @@ function MyPage() {
         <h3 className="text-lg font-bold text-red-500 mb-4">Danger Zone</h3>
 
         <div className="border border-red-200 rounded-lg p-4 mb-4">
-          <div className="flex justify-between items-center">
-            <div>
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center">
+            <div className="mb-3 sm:mb-0 sm:pr-4">
               <p className="text-textmain font-medium">커플 연결 끊기</p>
               <p className="text-textsub text-sm">
                 파트너와의 연결을 해제합니다. 이 작업은 되돌릴 수 없습니다.
               </p>
             </div>
             <button
-              className="px-4 py-2 bg-white text-red-500 border border-red-500 rounded-lg hover:bg-red-50"
+              className="w-full sm:w-auto px-4 py-2 bg-white text-red-500 border border-red-500 rounded-lg hover:bg-red-50 whitespace-nowrap"
               onClick={() => setShowBreakupModal(true)}
             >
               연결 끊기
@@ -588,8 +702,8 @@ function MyPage() {
         </div>
 
         <div className="border border-red-200 rounded-lg p-4">
-          <div className="flex justify-between items-center">
-            <div>
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center">
+            <div className="mb-3 sm:mb-0 sm:pr-4">
               <p className="text-textmain font-medium">회원 탈퇴</p>
               <p className="text-textsub text-sm">
                 계정을 영구적으로 삭제합니다. 모든 데이터가 삭제되며 복구할 수
@@ -597,7 +711,7 @@ function MyPage() {
               </p>
             </div>
             <button
-              className="px-4 py-2 bg-white text-red-500 border border-red-500 rounded-lg hover:bg-red-50"
+              className="w-full sm:w-auto px-4 py-2 bg-white text-red-500 border border-red-500 rounded-lg hover:bg-red-50 whitespace-nowrap"
               onClick={() => setShowDeleteModal(true)}
             >
               탈퇴하기


### PR DESCRIPTION
## ✨ Feature: 마이페이지 및 회원 복구 기능 개발

### 📝 작업 개요 (Summary)
- 마이페이지 및 회원 복구 기능 개발

### 🎯 목표 및 완료 조건 (Goals / Done Criteria)
- [X] 마이페이지 백엔드 연결(조회 및 수정)
- [X] 커플 연결 끊기, 회원 탈퇴 
- [X] 회원 복구 페이지 및 백엔드 연결

### 📋 구현 상세 (Details)
- 마이페이지 UI에서 사용자 정보를 백엔드와 연동하여 실시간으로 조회 및 수정 가능하게 구현
- 커플 연결 해제 시 사용자 userCode를 새로 발급하고, coupleId 삭제 처리
- 회원 탈퇴 시 사용자 상태를 INACTIVE로 변경하고, 관련 데이터 로직 정비
- 탈퇴한 사용자는 복구 페이지를 통해 로그인 후 계정 복구 가능
- 생년월일 입력 시 localStorage에 birth 저장 및 API 예외 처리 추가
- 커플 연결 완료 시 localStorage에 coupleId 저장, userCode는 삭제

### 🧩 영향 범위
- 마이페이지 및 회원 상태 관리 관련 프론트 페이지
- 사용자 상태, 커플 연결 관리 로직, 인증 및 로그인 플로우